### PR TITLE
Pin pnpm/action-setup Manually

### DIFF
--- a/.github/actions/setup-node-pnpm/action.yaml
+++ b/.github/actions/setup-node-pnpm/action.yaml
@@ -21,7 +21,7 @@ runs:
         echo "pnpm-version=$(jq -r '.volta.pnpm' ${{ inputs.pnpm-version-file }})" >> "$GITHUB_OUTPUT"
 
     - name: Setup pnpm
-      uses: pnpm/action-setup@v3
+      uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d # v3
       with:
         version: ${{ steps.extract-pnpm-version.outputs.pnpm-version }}
 


### PR DESCRIPTION
## What's Changed
Pin pnpm/action-setup manually; renovate does not detect this action.

## What not to Do Now

## References
